### PR TITLE
bugfix/fixed-bugs+scrollUpAfterFechNewPage

### DIFF
--- a/src/components/changePage/changePage.js
+++ b/src/components/changePage/changePage.js
@@ -6,9 +6,10 @@ element.addEventListener('click', supportForChangePage);
 const header = document.querySelector("header");
 
 function supportForChangePage(evt) {
+  header.scrollIntoView({behavior: 'smooth'});
+  
   const pageBtn = evt.target;
   pageNum = pageBtn.id.split("_").slice(1);
 
   popularMovies(pageNum);
-  header.scrollIntoView({behavior: 'smooth'});
 }

--- a/src/components/changePage/changePage.js
+++ b/src/components/changePage/changePage.js
@@ -3,9 +3,12 @@ import popularMovies from "../popularMovies/popularMovies";
 const element = document.querySelector(".pagination ul");
 element.addEventListener('click', supportForChangePage);
 
+const header = document.querySelector("header");
+
 function supportForChangePage(evt) {
   const pageBtn = evt.target;
   pageNum = pageBtn.id.split("_").slice(1);
 
   popularMovies(pageNum);
+  header.scrollIntoView({behavior: 'smooth'});
 }

--- a/src/components/movieModal/movieModal.js
+++ b/src/components/movieModal/movieModal.js
@@ -40,5 +40,5 @@ export function initializeModal() {
       }
       clearInterval(timer);
     }
-  }, 10);
+  }, 100);
 }

--- a/src/components/movieModalMarkup/movieModalMarkup.js
+++ b/src/components/movieModalMarkup/movieModalMarkup.js
@@ -54,7 +54,6 @@ export default function movieModalMarkup(id) {
 
   fetchMoviesById(id)
   .then(response => {
-      console.log(`output markupu dla 'modal'`);
       return htmlOutput.insertAdjacentHTML(
         'beforeend',
         htmlMarkup(response)

--- a/src/components/moviesListMarkup/moviesListMarkup.js
+++ b/src/components/moviesListMarkup/moviesListMarkup.js
@@ -30,7 +30,6 @@ export default function moviesListMarkup(pageNumber = 1, whatToOutput = 'trendin
     case 'trending':
       fetchTrendyMovies(pageNumber)
         .then(response => {
-          console.log(`output markupu dla 'trending'`);
           page = response.page;
           totalPages = response.total_pages;
 
@@ -48,7 +47,6 @@ export default function moviesListMarkup(pageNumber = 1, whatToOutput = 'trendin
       break;
 
     case 'watched':
-      console.log(`output markupu dla 'watched'`);
       if (getFromLocalStorage('watched') !== []) {
         return markupOutput.insertAdjacentHTML(
           'beforeend',
@@ -60,7 +58,6 @@ export default function moviesListMarkup(pageNumber = 1, whatToOutput = 'trendin
       break;
 
     case 'queue':
-      console.log(`output markupu dla 'queue'`);
       if (getFromLocalStorage('queue') !== []) {
         return markupOutput.insertAdjacentHTML(
           'beforeend',

--- a/src/components/pagination/pagination.js
+++ b/src/components/pagination/pagination.js
@@ -10,7 +10,7 @@ export default function createPagination(totalPages, page){
   let afterPage = page + 1;
 
   if (page > 1){ //show the next button if the page value is greater than 1
-    liTag += `<li class="btn prev" id="page_${beforePage}"></li>`;
+    liTag += `<li class="btn prev" id="page_${page - 1}"></li>`;
   }
   
   if (page > 2){ //if page value is less than 2 then add 1 after the previous button
@@ -60,7 +60,7 @@ export default function createPagination(totalPages, page){
   }
 
   if (page < totalPages) { //show the next button if the page value is less than totalPage(20)
-    liTag += `<li class="btn next" id="page_${afterPage}"></li>`;
+    liTag += `<li class="btn next" id="page_${page + 1}"></li>`;
   }
 
   element.innerHTML = liTag; //add li tag inside ul tag

--- a/src/components/supportForMyLibrary/supportForMyLibrary.js
+++ b/src/components/supportForMyLibrary/supportForMyLibrary.js
@@ -2,27 +2,28 @@ import dynamicChangeBtnsState from "../dynamicChangeBtnsState/dynamicChangeBtnsS
 import getFromLocalStorage from "../getFromLocalStorage/getFromLocalStorage";
 import setToLocalStorage from "../setToLocalStorage/setToLocalStorage";
 
+// Okno modalne
 const modalWrapper = document.querySelector('.modal--wrapper');
 
+// Event click na modalu
 modalWrapper.addEventListener("click", localStorageSupport);
 
-if (modalWrapper.querySelector(".modal__btns")) {
-  console.log("tak ma");
-}
-
 function localStorageSupport(evt) {
+  // Jeśli cel zdarzenia zawiera klasę "modal__btns" to wykonaj
   if (evt.target.classList.contains("modal__btns")) {
     const btn = evt.target;
     const {id, name} = btn.dataset;
     const idNumber = Number(id);
 
+    // Jeśli w lokalStorage nie ma klucza odpowiednio "watched" lub "queue" to utwórz pustą tablicę na filmy
     if (!getFromLocalStorage(name)) {
       setToLocalStorage(name, []);
     }
 
     const get = getFromLocalStorage(name);
+    // Jeśli klucz odpowiednio "watched" lub "queue" zawiera id filmu to wykonaj
     if (get.includes(idNumber)) {
-      const remove = get.filter(val => val !== val);
+      const remove = get.filter(val => val !== idNumber);
       setToLocalStorage(name, remove);
     } else {
       switch (name) {
@@ -33,7 +34,8 @@ function localStorageSupport(evt) {
           }
           const getNext = getFromLocalStorage(next);
           if (getNext.includes(idNumber)) {
-            const removeNext = getNext.filter(val => val !== val);
+            const removeNext = getNext.filter(val => val !== idNumber);
+            console.log(removeNext);
             setToLocalStorage(next, removeNext);
           }
           break;
@@ -45,7 +47,7 @@ function localStorageSupport(evt) {
           }
           const getPrev = getFromLocalStorage(prev);
           if (getPrev.includes(idNumber)) {
-            const removePrev = getPrev.filter(val => val !== val);
+            const removePrev = getPrev.filter(val => val !== idNumber);
             setToLocalStorage(prev, removePrev);
           }
           break;


### PR DESCRIPTION
Bugs fixed:
1. The "next page" button, selected on the first page currently displayed, moves three pages forward
2. The "Remove from watched / queue" buttons remove the entire array instead of a single record
3. Modal does not open when the page loads longer - reloading necessary, i.e. weak UI

Added functionalities:
1. After selecting a page in pagination, when reloading it scrolls to the top of the page